### PR TITLE
Fix prod healthcheck: use curl instead of missing wget

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     healthcheck:
-      test: ["CMD", "wget", "-O", "-", "http://localhost:8000/test"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/test"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- `docker-compose.prod.yml` healthcheck uses `wget`, but the container image only ships `curl` and `python3`
- Every healthcheck exec on the server has failed since startup with `exec: "wget": executable file not found in $PATH` — 14k+ consecutive failures over ~5 days
- App itself is healthy (`/test` returns `Flask server is running!`); only the healthcheck reporting is broken
- `docker-compose.yml` already uses `curl`; this brings the prod variant in line

## Test plan
- [x] Verified `curl -fsS http://localhost:8000/test` inside the running container exits 0
- [x] Confirmed image has no baked-in `HEALTHCHECK` instruction that would conflict
- [ ] After merge: sync updated compose to server and `docker compose up -d` to recreate web container, then confirm `docker inspect ... --format '{{.State.Health.Status}}'` reports `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)