### PR TITLE
Deploy healthcheck fix (PR #14)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     healthcheck:
-      test: ["CMD", "wget", "-O", "-", "http://localhost:8000/test"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/test"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Propagate PR #14 (wget → curl in docker-compose.prod.yml) from main into deploy so the server can sync to a correct compose file.

No image rebuild needed — this is a compose-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)